### PR TITLE
Adapting `make_quant` to reassign `param` to `default_unit`

### DIFF
--- a/hasasia/sensitivity.py
+++ b/hasasia/sensitivity.py
@@ -850,7 +850,7 @@ def make_quant(param, default_unit):
         except u.UnitConversionError:
             raise ValueError("Quantity {0} with incompatible unit {1}"
                              .format(param, default_unit))
-        quantity = param
+        quantity = param.to(default_unit)
     else:
         quantity = param * default_unit
 


### PR DESCRIPTION
If a variable is already assigned an astropy quantity, make_quant doesn't actually change it because in line 853 it assigns `quantity` to `param`, not `param.to(default_unit)`. 